### PR TITLE
legacy: Allow qcom power HAL to interact with perfd

### DIFF
--- a/legacy-common/hal_power_default.te
+++ b/legacy-common/hal_power_default.te
@@ -1,0 +1,4 @@
+allow hal_power_default mpctl_socket:dir search;
+allow hal_power_default mpctl_socket:sock_file write;
+
+allow hal_power_default mpdecision:unix_stream_socket connectto;

--- a/legacy-common/mpdecision.te
+++ b/legacy-common/mpdecision.te
@@ -3,3 +3,5 @@ allow mpdecision sysfs_kgsl:file rw_file_perms;
 allow mpdecision sysfs_runtime_status:file r_file_perms;
 
 get_prop(mpdecision, freq_prop)
+
+r_dir_file(mpdecision, hal_power_default)


### PR DESCRIPTION
Change-Id: Ib43f7575cefdeddcc02a3a6240c6f38aef18300d